### PR TITLE
Remove ampersands from metadata URLs

### DIFF
--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -2,6 +2,8 @@
 
 namespace Pressbooks\Shibboleth;
 
+use function Pressbooks\Utility\str_remove_prefix;
+use function Pressbooks\Utility\str_starts_with;
 use PressbooksMix\Assets;
 
 /**
@@ -250,9 +252,9 @@ class SAML {
 	public function authenticate( $user, $username, $password ) {
 		$saml_action = '';
 		$use_shibboleth = false;
-		if ( isset( $_REQUEST['action'] ) && $_REQUEST['action'] === 'pb_shibboleth' ) { // @codingStandardsIgnoreLine
+		if ( isset( $_REQUEST['action'] ) && str_starts_with( $_REQUEST['action'], 'pb_shibboleth' ) ) { // @codingStandardsIgnoreLine
 			$use_shibboleth = true;
-			$saml_action = isset( $_REQUEST['saml'] ) ? $_REQUEST['saml'] : ''; // @codingStandardsIgnoreLine
+			$saml_action = ltrim( str_remove_prefix( $_REQUEST['action'], 'pb_shibboleth' ), '_' ); // @codingStandardsIgnoreLine
 		}
 
 		if ( $saml_action === 'metadata' ) {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -34,7 +34,7 @@ function login_url() {
  * @return string
  */
 function metadata_url() {
-	return add_query_arg( 'saml', 'metadata', login_url() );
+	return add_query_arg( 'action', 'pb_shibboleth_metadata', login_url() );
 }
 
 /**
@@ -43,7 +43,7 @@ function metadata_url() {
  * @return string
  */
 function acs_url() {
-	return add_query_arg( 'saml', 'acs', login_url() );
+	return add_query_arg( 'action', 'pb_shibboleth_acs', login_url() );
 }
 
 /**
@@ -52,5 +52,5 @@ function acs_url() {
  * @return string
  */
 function sls_url() {
-	return add_query_arg( 'saml', 'sls', login_url() );
+	return add_query_arg( 'action', 'pb_shibboleth_sls', login_url() );
 }

--- a/tests/test-namespace.php
+++ b/tests/test-namespace.php
@@ -35,19 +35,19 @@ class NamespaceTest extends \WP_UnitTestCase {
 	public function test_metadata_url() {
 		$url = \Pressbooks\Shibboleth\metadata_url();
 		$this->assertTrue( filter_var( $url, FILTER_VALIDATE_URL ) !== false );
-		$this->assertContains( 'saml=metadata', $url );
+		$this->assertContains( 'action=pb_shibboleth_metadata', $url );
 	}
 
 	public function test_acs_url() {
 		$url = \Pressbooks\Shibboleth\acs_url();
 		$this->assertTrue( filter_var( $url, FILTER_VALIDATE_URL ) !== false );
-		$this->assertContains( 'saml=acs', $url );
+		$this->assertContains( 'action=pb_shibboleth_acs', $url );
 	}
 
 	public function test_sls_url() {
 		$url = \Pressbooks\Shibboleth\sls_url();
 		$this->assertTrue( filter_var( $url, FILTER_VALIDATE_URL ) !== false );
-		$this->assertContains( 'saml=sls', $url );
+		$this->assertContains( 'action=pb_shibboleth_sls', $url );
 	}
 
 }


### PR DESCRIPTION
There aren't any ampersands in the entityIDs InCommon metadata aggregate, so it appears that this is not common practice. Recreated metadata removing the problematic character