### PR TITLE
Associate existing users with either mail or eduPersonPrincipalName

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** pressbooks, saml, saml2, sso, shibboleth  
 **Requires at least:** 4.9.7  
 **Tested up to:** 4.9  
-**Stable tag:** 0.0.3  
+**Stable tag:** 0.0.4  
 **License:** GPLv3 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-3.0.html  
 
@@ -72,6 +72,10 @@ Because this plugin uses the fabulous [onelogin/php-saml](https://github.com/one
 ## Changelog 
 
 
+### 0.0.4 
+ * Associate existing users with either mail or eduPersonPrincipalName
+
+
 ### 0.0.3 
 * Use certificate to set Valid Until
 * Interoperable SAML 2.0 Web Browser SSO Profile
@@ -90,5 +94,5 @@ Because this plugin uses the fabulous [onelogin/php-saml](https://github.com/one
 ## Upgrade Notice 
 
 
-### 0.0.3 
+### 0.0.4 
 * Pressbooks Shibboleth Single Sign-On requires Pressbooks >= 5.4 and WordPress >= 4.9

--- a/pressbooks-shibboleth-sso.php
+++ b/pressbooks-shibboleth-sso.php
@@ -3,7 +3,7 @@
 Plugin Name: Pressbooks Shibboleth Single Sign-On
 Plugin URI: https://pressbooks.org
 Description: Shibboleth Single Sign-On integration for Pressbooks.
-Version: 0.0.3
+Version: 0.0.4
 Author: Pressbooks (Book Oven Inc.)
 Author URI: https://pressbooks.org
 Pressbooks tested up to: 5.5.0

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://opencollective.com/pressbooks/
 Tags: pressbooks, saml, saml2, sso, shibboleth
 Requires at least: 4.9.7
 Tested up to: 4.9
-Stable tag: 0.0.3
+Stable tag: 0.0.4
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -66,6 +66,9 @@ Because this plugin uses the fabulous [onelogin/php-saml](https://github.com/one
 
 == Changelog ==
 
+= 0.0.4 =
+ * Associate existing users with either mail or eduPersonPrincipalName
+
 = 0.0.3 =
 * Use certificate to set Valid Until
 * Interoperable SAML 2.0 Web Browser SSO Profile
@@ -80,5 +83,5 @@ Because this plugin uses the fabulous [onelogin/php-saml](https://github.com/one
 
 == Upgrade Notice ==
 
-= 0.0.3 =
+= 0.0.4 =
 * Pressbooks Shibboleth Single Sign-On requires Pressbooks >= 5.4 and WordPress >= 4.9

--- a/tests/test-saml.php
+++ b/tests/test-saml.php
@@ -217,7 +217,13 @@ class SamlTest extends \WP_UnitTestCase {
 		// Try to find the user and fail
 		$this->assertFalse( $this->saml->findExistingUser( 'nobody@pressbooks.test' ) );
 
-		// Try to find the user and succeed thanks to fallback info in the session
+		// Try to find the user and fail again
+		$_SESSION[ \Pressbooks\Shibboleth\SAML::USER_DATA ] = [
+			'mail' => [ 'one@pressbooks.test', 'two@pressbooks.test' ],
+		];
+		$this->assertFalse( $this->saml->findExistingUser( 'nobody@pressbooks.test' ) );
+
+		// Try to find the user and succeed thanks to fallback eduPersonPrincipalName info in the session
 		$_SESSION[ \Pressbooks\Shibboleth\SAML::USER_DATA ] = [
 			'mail' => [ 'one@pressbooks.test', 'two@pressbooks.test' ],
 			'eduPersonPrincipalName' => [ 'three@pressbooks.test', $email ],


### PR DESCRIPTION
Note: 

> Syntactically, ePPN looks like an email address but is not intended to be a person's published email address or be used as an email address.

Source: https://www.switch.ch/aai/support/documents/attributes/edupersonprincipalname/
