### PR TITLE
fix: improve network admin notices

### DIFF
--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -155,7 +155,7 @@ class SAML {
 			$options['idp_sso_logout_url'] ?? ''
 		);
 
-		if ( ! $this->verifyPluginSetup( $options ) ) {
+		if ( $this->areOptionsEmpty( $options ) ) {
 			if ( 'pb_saml_admin' !== @$_REQUEST['page'] ) { // @codingStandardsIgnoreLine
 				add_action(
 					'network_admin_notices', function () {
@@ -212,10 +212,10 @@ class SAML {
 	 *
 	 * @return bool
 	 */
-	public function verifyPluginSetup( array $options ): bool {
-		return ! empty( $options['idp_entity_id'] ) &&
-			! empty( $options['idp_sso_login_url'] ) &&
-			! empty( $options['idp_x509_cert'] );
+	public function areOptionsEmpty( array $options ): bool {
+		return empty( $options['idp_entity_id'] ) &&
+			empty( $options['idp_sso_login_url'] ) &&
+			empty( $options['idp_x509_cert'] );
 }
 
 	/**

--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -160,18 +160,26 @@ class SAML {
 				add_action(
 					'network_admin_notices', function () {
 						echo '<div id="message" role="alert" class="error fade"><p>' .
-							__( 'The Pressbooks SAML Plugin has not been <a href="' .
-							network_admin_url( 'admin.php?page=pb_saml_admin' ) .
-							'">configured</a> yet.', 'pressbooks-saml-sso' ) . '</p></div>';
+							sprintf(
+								__(
+									'The Pressbooks SAML Plugin has not been <a href="%1$s">configured</a> yet.',
+									'pressbooks-saml-sso'
+								),
+								network_admin_url( 'admin.php?page=pb_saml_admin' )
+							) . '</p></div>';
 					}
 				);
 			}
 			return;
 		}
 
-		$configuration_error_message = __( 'The Pressbooks SAML Plugin is not <a href="' .
-				network_admin_url( 'admin.php?page=pb_saml_admin' ) .
-				'">configured</a> correctly.', 'pressbooks-saml-sso' );
+		$configuration_error_message = sprintf(
+			__(
+				'The Pressbooks SAML Plugin is not <a href="%1$s">configured</a> correctly.',
+				'pressbooks-saml-sso'
+			),
+			network_admin_url( 'admin.php?page=pb_saml_admin' )
+		);
 
 		if ( ! filter_var( $options['idp_sso_login_url'], FILTER_VALIDATE_URL ) ) {
 			add_action(
@@ -216,7 +224,7 @@ class SAML {
 		return empty( $options['idp_entity_id'] ) &&
 			empty( $options['idp_sso_login_url'] ) &&
 			empty( $options['idp_x509_cert'] );
-}
+	}
 
 	/**
 	 * @return array

--- a/tests/test-saml.php
+++ b/tests/test-saml.php
@@ -210,17 +210,17 @@ class SamlTest extends \WP_UnitTestCase {
 	// Tests
 	// ------------------------------------------------------------------------
 
-	public function test_verifyPluginSetup() {
-		$this->assertFalse( $this->saml->verifyPluginSetup( [] ) );
+	/**
+	 * @test
+	 */
+	public function it_checks_empty_options(): void {
+		$this->assertTrue( $this->saml->areOptionsEmpty( [] ) );
 
 		$options = [
 			'idp_entity_id' => 1,
 			'idp_x509_cert' => 3,
 		];
-		$this->assertFalse( $this->saml->verifyPluginSetup( $options ) );
-
-		$options['idp_sso_login_url'] = 'https://pressbooks.test/login';
-		$this->assertTrue( $this->saml->verifyPluginSetup( $options ) );
+		$this->assertFalse( $this->saml->areOptionsEmpty( $options ) );
 	}
 
 	public function test_getSamlSettings() {

--- a/tests/test-saml.php
+++ b/tests/test-saml.php
@@ -215,7 +215,6 @@ class SamlTest extends \WP_UnitTestCase {
 
 		$options = [
 			'idp_entity_id' => 1,
-			'idp_sso_login_url' => 2,
 			'idp_x509_cert' => 3,
 		];
 		$this->assertFalse( $this->saml->verifyPluginSetup( $options ) );
@@ -232,7 +231,7 @@ class SamlTest extends \WP_UnitTestCase {
 		$this->saml->setSamlSettings( 1, 2, 3 );
 		$s = $this->saml->getSamlSettings();
 		$this->assertEquals( $s['idp']['entityId'], 1 );
-		$this->assertEquals( $s['idp']['singleSignOnService']['url'], 2 );
+		$this->assertNull( $s['idp']['singleSignOnService']['url'] );
 		$this->assertEquals( $s['idp']['x509cert'], 3 );
 		$this->assertEquals( $s['sp']['attributeConsumingService']['serviceName'], 'Pressbooks' );
 		$this->assertEquals( $s['sp']['attributeConsumingService']['requestedAttributes'][0]['friendlyName'], 'uid' );
@@ -255,7 +254,7 @@ class SamlTest extends \WP_UnitTestCase {
 		$this->saml->setSamlSettings( 1, 2, 3, 4 );
 		$s = $this->saml->getSamlSettings();
 		$this->assertEquals( $s['idp']['entityId'], 1 );
-		$this->assertEquals( $s['idp']['singleSignOnService']['url'], 2 );
+		$this->assertNull( $s['idp']['singleSignOnService']['url'] );
 		$this->assertEquals( $s['idp']['x509cert'], 3 );
 		$this->assertEquals( $s['idp']['singleLogoutService']['url'], 4 );
 		$this->assertEquals( $s['sp']['attributeConsumingService']['serviceName'], 'Pressbooks' );


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-saml-sso/issues/144

This PR changes the network admin notices for Plugin configuration messages, according to the new specs.

### Testing case
- In the sidebar menu > Integrations > SAML2 leave all the settings blank.
- You should see: "_The Pressbooks SAML Plugin has not been [configured](https://pressbooks.test/wp-admin/network/admin.php?page=pb_saml_admin) yet_" message.
- Complete all the settings but add any invalid settings, like leaving blank the SingleSignOnService value.
- You should see now: "_The Pressbooks SAML Plugin is not [configured](https://pressbooks.test/wp-admin/network/admin.php?page=pb_saml_admin) correctly._" message.