### PR TITLE
fix: redirect regular users to previous URL with forced redirection option

### DIFF
--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -706,7 +706,6 @@ class SAML {
 				}
 				if ( $this->forcedRedirection && empty( $_SESSION[ self::USER_DATA ] ) ) {
 					remove_filter( 'login_url', [ $this, 'changeLoginUrl' ], 999 );
-					return wp_login_url();
 				}
 			}
 		}


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/private/issues/941

This PR fixes the logout redirection behaviour for regular WP users when the `Hide the Pressbooks login page. (forced redirection)` option enabled. 

### Bug description
- Log in as an admin through WP flow and on Integrations > SAML2 settings page, enable the `Hide the Pressbooks login page.` option and save it.
- Go to the network home page (or any other public page as an example).
- Click on Sign Out at the top of the home page.

#### Expected behaviour
The user is logged out and redirected to the previous page (the Network home page in the test case).

#### Current behaviour
The user is logged out and redirected to the WP Login page.

### Test case
Follow the previous steps, and make sure the behaviour is the expected one.
