### PR TITLE
fix: use sessions for SLO action

### DIFF
--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -121,7 +121,7 @@ class SAML {
 		add_filter( 'authenticate', [ $obj, 'authenticate' ], 10, 3 );
 		add_action( 'login_enqueue_scripts', [ $obj, 'loginEnqueueScripts' ] );
 		add_action( 'login_form', [ $obj, 'loginForm' ] );
-		add_filter( 'logout_redirect', [ $obj, 'logoutRedirect' ] );
+		add_filter( 'init', [ $obj, 'logoutRedirect' ] );
 		add_filter( 'show_password_fields', [ $obj, 'showPasswordFields' ], 10, 2 );
 	}
 
@@ -291,13 +291,13 @@ class SAML {
 			'serviceName' => 'Pressbooks',
 			'requestedAttributes' => [
 				[
-					'nameFormat' => \OneLogin\Saml2\Constants::ATTRNAME_FORMAT_URI,
+					'nameFormat' => '',
 					'isRequired' => true,
 					'name' => 'urn:oid:0.9.2342.19200300.100.1.1',
 					'friendlyName' => 'uid',
 				],
 				[
-					'nameFormat' => \OneLogin\Saml2\Constants::ATTRNAME_FORMAT_URI,
+					'nameFormat' => '',
 					'isRequired' => true,
 					'name' => 'urn:oid:0.9.2342.19200300.100.1.3',
 					'friendlyName' => 'mail',
@@ -596,15 +596,7 @@ class SAML {
 			'nameIdSPNameQualifier' => $this->auth->getNameIdSPNameQualifier(),
 		];
 
-		setcookie(
-			self::AUTH_DATA,
-			base64_encode( json_encode( $auth_data ) ),
-			0,
-			COOKIEPATH,
-			COOKIE_DOMAIN,
-			is_ssl(),
-			true
-		);
+		$_SESSION[ self::AUTH_DATA ] = $auth_data;
 
 		$this->logAuthData();
 	}
@@ -691,34 +683,45 @@ class SAML {
 		return $email ? $email : '';
 	}
 
-	public function logoutRedirect( string $redirect_to ): ?string {
-		if ( $this->samlClientIsReady ) {
-			$user_auth_data = $_COOKIE[ self::AUTH_DATA ] ?? null;
-
-			if ( $user_auth_data ) {
-				$user_auth_data = json_decode( base64_decode( $user_auth_data ), true );
-				setcookie( self::AUTH_DATA, '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN );
-			}
-
-			if ( $this->forcedRedirection || $user_auth_data || get_user_meta( $this->currentUserId, self::META_KEY, true ) ) {
-				if ( ! empty( $this->auth->getSLOurl() ) && ! empty( $user_auth_data ) ) {
-					$this->auth->logout(
-						add_query_arg( 'loggedout', true, wp_login_url() ),
-						[],
-						$user_auth_data['nameId'],
-						$user_auth_data['sessionIndex'],
-						false,
-						$user_auth_data['nameFormat'],
-						$user_auth_data['nameIdNameQualifier'],
-						$user_auth_data['nameIdSPNameQualifier']
-					);
-				}
-				if ( $this->forcedRedirection && $user_auth_data ) {
-					remove_filter( 'login_url', [ $this, 'changeLoginUrl' ], 999 );
-				}
-			}
+	public function logoutRedirect(): bool {
+		if ( ! isset( $_GET['action'] ) || $_GET['action'] !== 'logout' ) {
+			return false;
 		}
-		return $redirect_to;
+
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		if ( ! $this->samlClientIsReady ) {
+			return false;
+		}
+
+		$user_auth_data = $_SESSION[ self::AUTH_DATA ] ?? null;
+		$user_has_meta = get_user_meta( $this->currentUserId, self::META_KEY, true );
+		$can_trigger_logout = $user_auth_data && ! empty( $this->auth->getSLOurl() );
+
+		if ( $this->forcedRedirection || $user_auth_data || $user_has_meta ) {
+			if ( $can_trigger_logout ) {
+				$this->auth->logout(
+					add_query_arg( 'loggedout', true, wp_login_url() ),
+					[],
+					$user_auth_data['nameId'],
+					$user_auth_data['sessionIndex'],
+					false,
+					$user_auth_data['nameFormat'],
+					$user_auth_data['nameIdNameQualifier'],
+					$user_auth_data['nameIdSPNameQualifier']
+				);
+			}
+
+			if ( $this->forcedRedirection && $user_auth_data ) {
+				remove_filter( 'login_url', [ $this, 'changeLoginUrl' ], 999 );
+			}
+
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,6 +13,7 @@ require_once $_tests_dir . '/includes/functions.php';
  */
 function _manually_load_plugin() {
 	require_once( __DIR__ . '/../../pressbooks/pressbooks.php' );
+	require_once( __DIR__ . '/../../pressbooks/tests/utils-trait.php' );
 	require_once( __DIR__ . '/../../pressbooks/requires.php' );
 	require_once( __DIR__ . '/../../pressbooks/requires-admin.php' );
 	require_once( __DIR__ . '/../pressbooks-saml-sso.php' );

--- a/tests/test-saml.php
+++ b/tests/test-saml.php
@@ -10,6 +10,8 @@ use PressbooksSamlSso\SAML;
 
 class SamlTest extends \WP_UnitTestCase {
 
+	use utilsTrait;
+
 	const TEST_FILE_PATH = __DIR__ . '/data/saml-log.csv';
 
 	// ------------------------------------------------------------------------
@@ -499,17 +501,17 @@ class SamlTest extends \WP_UnitTestCase {
 	public function test_logoutRedirect() {
 		$saml = new \PressbooksSamlSso\SAML( $this->getMockAdminWithForcedRedirection() );
 		$saml->setAuth( $this->getMockAuthSLO() );
-		setcookie(
-			SAML::AUTH_DATA,
-			base64_encode( json_encode( [ 'foo' => 'bar' ] ) ),
-			0,
-			COOKIEPATH,
-			COOKIE_DOMAIN,
-			is_ssl(),
-			true
-		);
 
-		$this->assertEquals( 'https://pressbooks.test', $saml->logoutRedirect( 'https://pressbooks.test' ) );
+		$_SESSION[ SAML::USER_DATA ] = [ 'foo' => 'bar' ];
+
+		$this->assertFalse( $saml->logoutRedirect() );
+
+		$user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		$_GET['action'] = 'logout';
+
+		$this->assertTrue( $saml->logoutRedirect() );
 	}
 
 	public function test_loginEnqueueScripts() {


### PR DESCRIPTION
This pull request refactors the SAML authentication system to improve session handling, update logout logic, and enhance test coverage. The key changes include replacing cookies with session storage for authentication data, modifying the logout flow, and updating tests to reflect the new implementation.

### Authentication and Session Handling:
* Replaced cookie-based storage of authentication data with session-based storage in the `persistSessionData` method (`inc/class-saml.php`).

### Logout Logic Updates:
* Updated the `logoutRedirect` method to use session data instead of cookies, added checks for user login status and action parameters, and simplified the logic for triggering SLO (Single Logout) (`inc/class-saml.php`). [[1]](diffhunk://#diff-cdef3d0de1baaf86b3e5d75d1a4e448ba10851e3425159bf36e18c91d09382b6L694-R704) [[2]](diffhunk://#diff-cdef3d0de1baaf86b3e5d75d1a4e448ba10851e3425159bf36e18c91d09382b6R716-R724)
* Changed the `logoutRedirect` filter to the `init` action to better align with the updated logout flow (`inc/class-saml.php`).

### SAML Attribute Configuration:
* Removed the `nameFormat` value for SAML attributes to use the default configuration (`inc/class-saml.php`).

### Testing Enhancements:
* Added the `utilsTrait` to the test suite for utility functions (`tests/bootstrap.php`, `tests/test-saml.php`). [[1]](diffhunk://#diff-96a82592013e5f4b91e682332583b7a4a6ca1ff0431d267c61179b1a21b167daR16) [[2]](diffhunk://#diff-ad00f6167340c22d14a3424f0668360b40437fef07d0e3f7125a63d03b63a788R13-R14)
* Updated the `test_logoutRedirect` method to validate the new session-based logout behavior and added assertions for different scenarios (`tests/test-saml.php`).