### PR TITLE
fix: accept auth data as parameter for logging & make nameFormat flexible

### DIFF
--- a/inc/class-saml.php
+++ b/inc/class-saml.php
@@ -291,13 +291,13 @@ class SAML {
 			'serviceName' => 'Pressbooks',
 			'requestedAttributes' => [
 				[
-					'nameFormat' => \OneLogin\Saml2\Constants::ATTRNAME_FORMAT_URI,
+					'nameFormat' => '',
 					'isRequired' => true,
 					'name' => 'urn:oid:0.9.2342.19200300.100.1.1',
 					'friendlyName' => 'uid',
 				],
 				[
-					'nameFormat' => \OneLogin\Saml2\Constants::ATTRNAME_FORMAT_URI,
+					'nameFormat' => '',
 					'isRequired' => true,
 					'name' => 'urn:oid:0.9.2342.19200300.100.1.3',
 					'friendlyName' => 'mail',
@@ -606,18 +606,17 @@ class SAML {
 			true
 		);
 
-		$this->logAuthData();
+		$this->logAuthData( $auth_data );
 	}
 
-	private function logAuthData(): bool {
-		$log_auth_data = $_COOKIE[ self::AUTH_DATA ] ?? null;
-		if ( ! $log_auth_data ) {
+	private function logAuthData( array $auth_data ): bool {
+		if ( empty( $auth_data ) ) {
 			return false;
 		}
 
-		$log_auth_data['sessionIndex'] = substr( $this->auth->getSessionIndex(), 0, 7 ) . '...';
-		$log_auth_data['nameId'] = substr( $this->auth->getNameId(), 0, 7 ) . '...';
-		$this->logData( 'Auth SAML data', $log_auth_data );
+		$auth_data['sessionIndex'] = substr( $this->auth->getSessionIndex(), 0, 7 ) . '...';
+		$auth_data['nameId'] = substr( $this->auth->getNameId(), 0, 7 ) . '...';
+		$this->logData( 'Auth SAML data', $auth_data );
 		return true;
 	}
 


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-saml-sso/issues/228

This pull request makes updates to the SAML authentication process in the `inc/class-saml.php` file, focusing on improving the handling of SAML attribute formats and refactoring the session logging mechanism.

### Updates to SAML Attribute Handling:
* Changed the `nameFormat` for requested attributes from `\OneLogin\Saml2\Constants::ATTRNAME_FORMAT_URI` to an empty string (`''`) to comply with updated attribute format requirements. (`[inc/class-saml.phpL294-R300](diffhunk://#diff-cdef3d0de1baaf86b3e5d75d1a4e448ba10851e3425159bf36e18c91d09382b6L294-R300)`)

### Refactoring of Session Logging:
* Updated the `persistSessionData` method to pass `$auth_data` explicitly to the `logAuthData` method instead of relying on cookie data, improving clarity and maintainability. (`[inc/class-saml.phpL609-R619](diffhunk://#diff-cdef3d0de1baaf86b3e5d75d1a4e448ba10851e3425159bf36e18c91d09382b6L609-R619)`)
* Refactored the `logAuthData` method to accept an `array $auth_data` parameter, removing dependency on `$_COOKIE` and ensuring the method operates on explicitly provided data. (`[inc/class-saml.phpL609-R619](diffhunk://#diff-cdef3d0de1baaf86b3e5d75d1a4e448ba10851e3425159bf36e18c91d09382b6L609-R619)`)